### PR TITLE
Potential fix for code scanning alert no. 40: Uncontrolled data used in path expression

### DIFF
--- a/Season-1/Level-3/code.py
+++ b/Season-1/Level-3/code.py
@@ -347,9 +347,9 @@ class TaxPayer:
         
         # The secure path is now completely sanitized and contains no user input
         try:
-            if not os.path.isfile(secure_path):
+            if not self._safe_file_check(secure_path, self.tax_forms_dir):
                 return None
-                
+            
             with open(secure_path, 'rb') as form:
                 _ = bytearray(form.read())
 


### PR DESCRIPTION
Potential fix for [https://github.com/krcm0209/skills-secure-code-game/security/code-scanning/40](https://github.com/krcm0209/skills-secure-code-game/security/code-scanning/40)

To fix the issue, we will enhance the sanitization and validation logic to ensure that no user-controlled data can influence the file path in a way that leads to unauthorized file access. Specifically:
1. Use `_safe_file_check` to validate the final `secure_path` before attempting to open the file. This ensures that the file is within the allowed base directory and exists as a regular file.
2. Ensure that all intermediate steps in the path sanitization process are robust against edge cases, such as unexpected characters or sequences.
3. Replace the direct use of `os.path.isfile` on line 350 with `_safe_file_check` to validate the file path securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
